### PR TITLE
Removing IAggregateIdentity<T>

### DIFF
--- a/src/EventSourcing.ApplicationService/ApplicationService.cs
+++ b/src/EventSourcing.ApplicationService/ApplicationService.cs
@@ -55,7 +55,7 @@ namespace EventSourcing.ApplicationService
         }
 
         protected void Update<TAggregate, TIdentity>(ICommand<TIdentity> command, Action<TAggregate> action)
-            where TAggregate : class, IAggregateRoot<TIdentity>
+            where TAggregate : class, IAggregateRoot
             where TIdentity : class, IAggregateIdentity
         {
             var aggregate = _repository.GetById<TAggregate>(command.Id);

--- a/src/EventSourcing.Example/ExampleAggregate.cs
+++ b/src/EventSourcing.Example/ExampleAggregate.cs
@@ -25,9 +25,9 @@ namespace EventSourcing.Example
         }
     }
 
-    public sealed class ExampleAggregate : AggregateRoot<ExampleId>
+    public sealed class ExampleAggregate : AggregateRoot
     {
-        public override ExampleId Id { get; protected set; }
+        public override IAggregateIdentity Id { get; protected set; }
 
         public ExampleAggregate()
             : this(new ConventionEventRouter())
@@ -56,7 +56,7 @@ namespace EventSourcing.Example
         }
     }
 
-    public sealed class AggregateWithStateClass : AggregateRoot<ExampleId>
+    public sealed class AggregateWithStateClass : AggregateRoot
     {
         private readonly ExampleState _state;
 
@@ -71,7 +71,7 @@ namespace EventSourcing.Example
             eventRouter.Register(_state);
         }
 
-        public override ExampleId Id
+        public override IAggregateIdentity Id
         {
             get { return _state.Id; }
             protected set { throw new NotSupportedException(); }

--- a/src/EventSourcing.Persistence.GetEventStore/GetEventStoreAsyncRepository.cs
+++ b/src/EventSourcing.Persistence.GetEventStore/GetEventStoreAsyncRepository.cs
@@ -65,7 +65,7 @@ namespace EventSourcing.Persistence.GetEventStore
             return _eventSerializer.Deserialize(eventData);
         }
 
-        public async Task SaveAsync<TIdentity>(IAggregateRoot<TIdentity> aggregate) where TIdentity : class, IAggregateIdentity
+        public async Task SaveAsync(IAggregateRoot aggregate)
         {
             var expectedVersion = aggregate.Version - aggregate.UncommittedEvents.Count();
             var eventData = aggregate.UncommittedEvents.Select(CreateEventData);

--- a/src/EventSourcing.Persistence.GetEventStore/GetEventStoreRepository.cs
+++ b/src/EventSourcing.Persistence.GetEventStore/GetEventStoreRepository.cs
@@ -64,8 +64,7 @@ namespace EventSourcing.Persistence.GetEventStore
             return events.Select(GetEvent).ToArray();
         }
 
-        public void Save<TIdentity>(IAggregateRoot<TIdentity> aggregate)
-            where TIdentity : class, IAggregateIdentity
+        public void Save(IAggregateRoot aggregate)
         {
             var streamName = GetStreamName(aggregate.Id);
             var expectedVersion = aggregate.Version - aggregate.UncommittedEvents.Count();

--- a/src/EventSourcing.Persistence/AsyncRepository.cs
+++ b/src/EventSourcing.Persistence/AsyncRepository.cs
@@ -7,7 +7,6 @@ namespace EventSourcing.Persistence
         Task<TAggregate> GetByIdAsync<TAggregate>(IAggregateIdentity aggregateId)
             where TAggregate : class, IAggregateRoot;
 
-        Task SaveAsync<TIdentity>(IAggregateRoot<TIdentity> aggregate)
-            where TIdentity : class, IAggregateIdentity;
+        Task SaveAsync(IAggregateRoot aggregate);
     }
 }

--- a/src/EventSourcing.Persistence/Repository.cs
+++ b/src/EventSourcing.Persistence/Repository.cs
@@ -11,8 +11,7 @@ namespace EventSourcing.Persistence
         TAggregate GetById<TAggregate>(IAggregateIdentity aggregateId)
             where TAggregate : class, IAggregateRoot;
 
-        void Save<TIdentity>(IAggregateRoot<TIdentity> aggregate)
-            where TIdentity : class, IAggregateIdentity;
+        void Save(IAggregateRoot aggregate);
     }
 
     public class Repository : IRepository
@@ -37,8 +36,7 @@ namespace EventSourcing.Persistence
             return aggregate;
         }
 
-        public void Save<TIdentity>(IAggregateRoot<TIdentity> aggregate)
-            where TIdentity : class, IAggregateIdentity
+        public void Save(IAggregateRoot aggregate)
         {
             var expectedVersion = aggregate.Version - aggregate.UncommittedEvents.Count();
             _store.AppendEventsToStream(aggregate.Id, expectedVersion, aggregate.UncommittedEvents.ToArray());
@@ -57,8 +55,7 @@ namespace EventSourcing.Persistence
             throw new NotImplementedException();
         }
 
-        public void Save<TIdentity>(IAggregateRoot<TIdentity> aggregate)
-            where TIdentity : class, IAggregateIdentity
+        public void Save(IAggregateRoot aggregate)
         {
             Contract.Requires<ArgumentNullException>(aggregate != null, "aggregate cannot be null");
             Contract.Requires<ArgumentException>(aggregate.UncommittedEvents != null, "aggregate.UncommittedEvents cannot be null");

--- a/src/EventSourcing/AggregateIdentity.cs
+++ b/src/EventSourcing/AggregateIdentity.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.Contracts;
 namespace EventSourcing
 {
     [ContractClass(typeof(AggregateIdentityContract))]
-    public interface IAggregateIdentity
+    public interface IAggregateIdentity : IEquatable<IAggregateIdentity>
     {
         /// <summary>
         /// Gets the id, converted to a string. Only alphanumerics and '-' are allowed.
@@ -43,6 +43,11 @@ namespace EventSourcing
             return Equals(obj as AbstractAggregateIdentity<TKey>);
         }
 
+        public bool Equals(IAggregateIdentity other)
+        {
+            return this.Equals(other as AbstractAggregateIdentity<TKey>);
+        }
+
         public bool Equals(AbstractAggregateIdentity<TKey> other)
         {
             if (other == null)
@@ -77,6 +82,12 @@ namespace EventSourcing
     [ContractClassFor(typeof(IAggregateIdentity))]
     internal abstract class AggregateIdentityContract : IAggregateIdentity
     {
+        [Pure]
+        public bool Equals(IAggregateIdentity other)
+        {
+            throw new NotImplementedException();
+        }
+
         [Pure]
         public string GetId()
         {

--- a/src/EventSourcing/AggregateRoot.cs
+++ b/src/EventSourcing/AggregateRoot.cs
@@ -9,25 +9,20 @@ namespace EventSourcing
     [ContractClass(typeof(AggregateRootContract))]
     public interface IAggregateRoot
     {
+        IAggregateIdentity Id { get; }
+
         int Version { get; }
 
         IUncommittedEvents UncommittedEvents { get; }
 
         void LoadFrom(IEnumerable<IEvent> history);
     }
-
-    public interface IAggregateRoot<out TIdentity> : IAggregateRoot
-        where TIdentity : IAggregateIdentity
-    {
-        TIdentity Id { get; }
-    }
     
     /// <summary>
     /// A generic aggregate root with wiring to apply events and keep uncommitted events
     /// </summary>
     /// <typeparam name="TIdentity"></typeparam>
-    public abstract class AggregateRoot<TIdentity> : IAggregateRoot<TIdentity>
-        where TIdentity : IAggregateIdentity
+    public abstract class AggregateRoot : IAggregateRoot
     {
         private readonly UncommittedEvents _uncommittedEvents = new UncommittedEvents();
 
@@ -40,7 +35,7 @@ namespace EventSourcing
             _eventRouter = eventRouter;
         }
 
-        public abstract TIdentity Id { get; protected set; }
+        public abstract IAggregateIdentity Id { get; protected set; }
 
         public int Version { get; private set; }
 
@@ -99,6 +94,11 @@ namespace EventSourcing
     [ContractClassFor(typeof(IAggregateRoot))]
     internal abstract class AggregateRootContract : IAggregateRoot
     {
+        public IAggregateIdentity Id
+        {
+            get { throw new NotImplementedException(); }
+        }
+
         public int Version
         {
             get { throw new NotImplementedException(); }


### PR DESCRIPTION
Removing type argument from IAggregateRoot, it will now just have an IAggregateIdentity
